### PR TITLE
release for macos based on the os version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,19 +80,21 @@ jobs:
       # macOS WITHOUT code signing
       #---------------------------------------------------------------------------------------
       - name: build and upload the app WITHOUT code signing (macOS x86)
-        if: matrix.platform == 'macos-13' && steps.shouldMacOSCodeSign.outputs.MACOS_CODE_SIGNING == 'false'
+        if: (matrix.platform == 'macos-13' || matrix.platform == 'macos-latest') && steps.shouldMacOSCodeSign.outputs.MACOS_CODE_SIGNING == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          PLATFORM_ID: ${{ matrix.platform }}
         run: |
           yarn build:mac-x64
           ls dist
 
       - name: build and upload the app WITHOUT code signing (macOS arm64)
-        if: matrix.platform == 'macos-latest' && steps.shouldMacOSCodeSign.outputs.MACOS_CODE_SIGNING == 'false'
+        if: (matrix.platform == 'macos-13' || matrix.platform == 'macos-latest') && steps.shouldMacOSCodeSign.outputs.MACOS_CODE_SIGNING == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          PLATFORM_ID: ${{ matrix.platform }}
         run: |
           yarn build:mac-arm64
           ls dist
@@ -101,7 +103,7 @@ jobs:
       #---------------------------------------------------------------------------------------
       # Note this issue regarding the if condition: https://github.com/actions/runner/issues/1173
       - name: build and upload the app WITH code signing (macOS x86)
-        if: matrix.platform == 'macos-13' && steps.shouldMacOSCodeSign.outputs.MACOS_CODE_SIGNING == 'true'
+        if: (matrix.platform == 'macos-13' || matrix.platform == 'macos-latest') && steps.shouldMacOSCodeSign.outputs.MACOS_CODE_SIGNING == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_DEV_IDENTITY: ${{ secrets.APPLE_DEV_IDENTITY }}
@@ -109,12 +111,13 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           DEBUG: electron-osx-sign*,electron-notarize*
+          PLATFORM_ID: ${{ matrix.platform }}
         run: |
           yarn build:mac-x64
           ls dist
 
       - name: build and upload the app WITH code signing (macOS arm64)
-        if: matrix.platform == 'macos-latest' && steps.shouldMacOSCodeSign.outputs.MACOS_CODE_SIGNING == 'true'
+        if: (matrix.platform == 'macos-13' || matrix.platform == 'macos-latest') && steps.shouldMacOSCodeSign.outputs.MACOS_CODE_SIGNING == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_DEV_IDENTITY: ${{ secrets.APPLE_DEV_IDENTITY }}
@@ -122,6 +125,7 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           DEBUG: electron-osx-sign*,electron-notarize*
+          PLATFORM_ID: ${{ matrix.platform }}
         run: |
           yarn build:mac-arm64
           ls dist

--- a/templates/electron-builder-template.yml
+++ b/templates/electron-builder-template.yml
@@ -25,7 +25,7 @@ mac:
   # - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
   notarize: false
 dmg:
-  artifactName: ${name}-${version}-${arch}.${ext}
+  artifactName: ${name}-${version}-${env.PLATFORM_ID}-${arch}.${ext}
 linux:
   target:
     - AppImage


### PR DESCRIPTION
This is a suggestion because many users are using `arm64` on an older version of macOS-13(specifically M1 and M2 users). But if we make a release for `arm64` only for the latest version the users see the issue that I have screenshot below.

With these updates, we can create individual releases for `arm64` and `x64` for `macos-13` and `macos-latest`

![Screenshot 2025-02-07 at 10 58 55 PM](https://github.com/user-attachments/assets/bee84bc0-8301-484d-a698-4d762d3bd5a4)
