### PR TITLE
Fix if statement for windows code signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -153,7 +153,7 @@ jobs:
           ls dist
 
           # If Windows EV code signing is set to true in kangaroo.config.ts, do code signing here
-          if [ "${{steps.shouldWindowsCodeSign.output.WINDOWS_CODE_SIGNING}}" == true ]; then
+          if [ "${{ steps.shouldWindowsCodeSign.outputs.WINDOWS_CODE_SIGNING }}" == "true" ]; then
 
             # Assumes this setup of EV certificates:
             # https://melatonin.dev/blog/how-to-code-sign-windows-installers-with-an-ev-cert-on-github-actions/


### PR DESCRIPTION
Addresses https://github.com/holochain/kangaroo-electron/issues/40

Has been tested successfully on branch [debug-windows-codesigning](https://github.com/holochain/kangaroo-electron/tree/debug-windows-codesigning), see [this action](https://github.com/holochain/kangaroo-electron/actions/runs/13854584241/job/38768507231) (the action fails because there are no code signing certificates but the code signing step is successfully being evoked now).