### PR TITLE
(Partially) fix systray icon size on macOS

### DIFF
--- a/scripts/create-icons.js
+++ b/scripts/create-icons.js
@@ -51,7 +51,7 @@ async function generateIcons() {
   if (!fs.existsSync(iconsDir)) {
     fs.mkdirSync(iconsDir);
   }
-  systrayIcon.write(path.join(iconsDir, '32x32@2.png'));
+  systrayIcon.write(path.join(iconsDir, '32x32@2x.png'));
 
   // Generate the icon for OS notifications
   console.log('Generating notifications icon');

--- a/src/main/const.ts
+++ b/src/main/const.ts
@@ -41,7 +41,7 @@ export const UI_DIRECTORY = path.join(RESOURCES_DIRECTORY, 'ui');
 
 export const ICON_PATH = path.join(RESOURCES_DIRECTORY, 'ui', 'icon.png');
 
-export const SYSTRAY_ICON_PATH = path.join(RESOURCES_DIRECTORY, 'icons', '32x32@2.png');
+export const SYSTRAY_ICON_PATH = path.join(RESOURCES_DIRECTORY, 'icons', '32x32@2x.png');
 export const NOTIFICATIONS_ICON_PATH = path.join(RESOURCES_DIRECTORY, 'icons', '128x128.png');
 
 export const isMac = process.platform === 'darwin';


### PR DESCRIPTION
Addresses https://github.com/holochain/kangaroo-electron/issues/38 partially. It has been reported to fix it on newer macOS but it did not fix it on an older macOS Catalina. The `@2x` in the filename is used to adjust resolution by macOS and it was accidentally wrongly typed.