### PR TITLE
feat: bump to holochain 0.5.3

### DIFF
--- a/kangaroo.config.ts
+++ b/kangaroo.config.ts
@@ -12,28 +12,28 @@ export default defineConfig({
   passwordMode: 'password-optional',
   bootstrapUrl: 'https://dev-test-bootstrap2.holochain.org/',
   signalUrl: 'wss://dev-test-bootstrap2.holochain.org/',
-  iceUrls: ['stun:stun.l.google.com:19302','stun:stun.cloudflare.com:3478'],
+  iceUrls: ['stun:stun.cloudflare.com:3478', 'stun:stun.l.google.com:19302'],
   bins: {
     holochain: {
-      version: '0.5.2',
+      version: '0.5.3',
       sha256: {
         'x86_64-unknown-linux-gnu':
-          'bbbdb2e52693522eaaaddafd392c9861db19210e02a48e1ff80d1077a296a08e',
+          '1165646324ad6ebd60fe8063a91ec4981dd1d7da64375603560fcc6b7ef511f7',
         'x86_64-pc-windows-msvc.exe':
-          'e111298fc3af3cc12bfc7adb742d5f29ced7d19f05267969a23d0b8e0d286d5c',
-        'x86_64-apple-darwin': '8bde56c485154b9ac31aa8a5c7232479503b6015fccf66035228b52680e2daf5',
-        'aarch64-apple-darwin': '3b6da6df698d86e5d66691b0c91c5ff0e308b07a400b7ea733f019ea62021cdd',
+          '143791e1c59dd718c5b60face20792a85b752ac3bba0e58b57469690c4be6a19',
+        'x86_64-apple-darwin': '540ef02bcfce6c91379e07df03d51afedc73a1f13df74e0cb9da6be58e147878',
+        'aarch64-apple-darwin': 'a42edb4e8580456c95f8c91ab0699d2b5fd1f73a5df0bdb9e4f20a102de0e988',
       },
     },
     lair: {
-      version: '0.6.1',
+      version: '0.6.2',
       sha256: {
         'x86_64-unknown-linux-gnu':
-          'c5d5d912af41f17def1c9d1027abd8eb6ce6f088871f4347ed38e124a93023cc',
+          '3c9ea3dbfc0853743dad3874856fdcfe391dca1769a6a81fc91b7578c73e92a7',
         'x86_64-pc-windows-msvc.exe':
-          'e11a0658c2d5a3c00409ea447241b3f1f3a215d70fa396b8a3ed633226f0a11f',
-        'x86_64-apple-darwin': 'fed0e9c3fc32589031229fb177ef3b3324e0096e742802898976812174bdd12d',
-        'aarch64-apple-darwin': 'dd36c33e495b8046501f0824fbc08f069973cab5ee210275ab9de3af932d79e8',
+          '6392ce85e985483d43fa01709bfd518f8f67aed8ddfa5950591b4ed51d226b8e',
+        'x86_64-apple-darwin': '746403e5d1655ecf14d95bccaeef11ad1abfc923e428c2f3d87c683edb6fdcdc',
+        'aarch64-apple-darwin': '05c7270749bb1a5cf61b0eb344a7d7a562da34090d5ea81b4c5b6cf040dd32e8',
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
-    "@holochain/client": "0.19.0-rc.0",
-    "@holochain/hc-spin-rust-utils": "0.500.0-rc.0",
+    "@holochain/client": "^0.19.0",
+    "@holochain/hc-spin-rust-utils": "^0.500.0",
     "@matthme/electron-updater": "6.3.0-alpha.1",
     "@msgpack/msgpack": "^2.8.0",
     "adm-zip": "0.5.14",

--- a/src/main/lairKeystore.ts
+++ b/src/main/lairKeystore.ts
@@ -69,9 +69,9 @@ export async function launchLairKeystore(
   });
   lairHandle.stdin.write(password);
   lairHandle.stdin.end();
-  // Wait for connection url or internal sodium error and return error or EventEmitter
+  // Wait for connection url or "internal" error and return error or EventEmitter
   lairHandle.stderr.pipe(split()).on('data', (line: string) => {
-    if (line.includes('InternalSodium')) {
+    if (line.includes('internal')) {
       kangarooEmitter.emit(WRONG_PASSWORD);
     } else {
       kangarooEmitter.emit(LAIR_ERROR, line);

--- a/yarn.lock
+++ b/yarn.lock
@@ -578,10 +578,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@holochain/client@0.19.0-rc.0":
-  version "0.19.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@holochain/client/-/client-0.19.0-rc.0.tgz#7e4f510a2518aca19ab72097117bbd01c1a45457"
-  integrity sha512-MFSsCy1BrtDlwlFSrt9ARa45c4QrplobRAZPuhqdHhTupI29ty6wj2Z44/G9XdhTv69xMCgq3Velx6GARGN+Cw==
+"@holochain/client@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@holochain/client/-/client-0.19.0.tgz#5bf3cf9ef58f2da9a060b31160daf197cfaf2346"
+  integrity sha512-LAiuQwyAQlLJp5Y0uT7EKuWy2AoCxMLdTECCLOs8ALADZzhNykFi2rmeC9hzskPXMR441bOhHPBWynqzQH95Ew==
   dependencies:
     "@bitgo/blake2b" "^3.2.4"
     "@msgpack/msgpack" "^3.1.1"
@@ -593,35 +593,35 @@
     lodash-es "^4.17.21"
     ws "^8.14.2"
 
-"@holochain/hc-spin-rust-utils-darwin-arm64@0.500.0-rc.0":
-  version "0.500.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@holochain/hc-spin-rust-utils-darwin-arm64/-/hc-spin-rust-utils-darwin-arm64-0.500.0-rc.0.tgz#6f023152e67db9e647b253d70f2436700bec9120"
-  integrity sha512-RBXskuvsfmTv3vYzctAJ03+CUb/IuqiAHKmAqBiMs6dQBP20sH0hPn3kKGk3uHeAhOD8JyPOetPeYZvYHAdAeQ==
+"@holochain/hc-spin-rust-utils-darwin-arm64@0.500.0":
+  version "0.500.0"
+  resolved "https://registry.yarnpkg.com/@holochain/hc-spin-rust-utils-darwin-arm64/-/hc-spin-rust-utils-darwin-arm64-0.500.0.tgz#9023d114623fbed8be52009b32107a7abf6a2546"
+  integrity sha512-C6eI1dhHFm8veDe5rJ1dn/fD5kNh+2M4D3UVKV+cKEgd7DO823hSSC1ArV9NoK2QiSL5VFVKqVhu0aadekNHlg==
 
-"@holochain/hc-spin-rust-utils-darwin-x64@0.500.0-rc.0":
-  version "0.500.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@holochain/hc-spin-rust-utils-darwin-x64/-/hc-spin-rust-utils-darwin-x64-0.500.0-rc.0.tgz#a06bf55e4a0ce9982a06e44828b630c9b892ac60"
-  integrity sha512-zykmX8rrDla3xnOIvFodS46/KTtNPFqbSiKG4cscahPD0fR0kX2DcFnISVQdxY/lsALgbj6kuLdG7K2zqkmN1Q==
+"@holochain/hc-spin-rust-utils-darwin-x64@0.500.0":
+  version "0.500.0"
+  resolved "https://registry.yarnpkg.com/@holochain/hc-spin-rust-utils-darwin-x64/-/hc-spin-rust-utils-darwin-x64-0.500.0.tgz#e65bf98d56091723aa599af500a1cc3acca75b56"
+  integrity sha512-qfdO9Ue0FDTueY+l96IJ/QEf6eT1ennwrJZ5jaHs32naF6IQ7bDC9wOvieFzHalMndObD6L3CyUY3DLQDEA+xQ==
 
-"@holochain/hc-spin-rust-utils-linux-x64-gnu@0.500.0-rc.0":
-  version "0.500.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@holochain/hc-spin-rust-utils-linux-x64-gnu/-/hc-spin-rust-utils-linux-x64-gnu-0.500.0-rc.0.tgz#9a8eb2a3a9759de530c024bb341b730d81809e17"
-  integrity sha512-2SWh93wPlHh+Zvom2HPHmfvcU6jmyNsNxImRwDFvJYdwdtJvGv9N2nnJO+Gu3sDTwRF1mXvgVbXCjKtSugnKjw==
+"@holochain/hc-spin-rust-utils-linux-x64-gnu@0.500.0":
+  version "0.500.0"
+  resolved "https://registry.yarnpkg.com/@holochain/hc-spin-rust-utils-linux-x64-gnu/-/hc-spin-rust-utils-linux-x64-gnu-0.500.0.tgz#2146b4732b2f19f4c713ea87b6b1838f351ff813"
+  integrity sha512-7jgjwvOVfYyqp/3/rie2KvwivxboenAZFzkW8RzsRCH+h5htA+uirkuCRqJYu7IZf2ukWZwfoFQKO5qmoIxRuw==
 
-"@holochain/hc-spin-rust-utils-win32-x64-msvc@0.500.0-rc.0":
-  version "0.500.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@holochain/hc-spin-rust-utils-win32-x64-msvc/-/hc-spin-rust-utils-win32-x64-msvc-0.500.0-rc.0.tgz#ffa07e7632109c5c9f4eb4b5e4b2e5772548fd77"
-  integrity sha512-hJQlBjDo/RKYTJH6gMPcWvRqKso8fpJaWGPJJftZzMEgv8vCUFqBcuCHzPQ7gdvfUQe9nDAywfgkGdo0c0oZkQ==
+"@holochain/hc-spin-rust-utils-win32-x64-msvc@0.500.0":
+  version "0.500.0"
+  resolved "https://registry.yarnpkg.com/@holochain/hc-spin-rust-utils-win32-x64-msvc/-/hc-spin-rust-utils-win32-x64-msvc-0.500.0.tgz#97e6568feaa6bdcba4e24de14d03ef70dd642221"
+  integrity sha512-MshgOZFjVaztX998iqP6fS4fj9jDHLm1+CCBvY5OTBpzaIw0y42C5ZTvSvuTa2mByr/LsJSwyyDLUnVYBqO9jg==
 
-"@holochain/hc-spin-rust-utils@0.500.0-rc.0":
-  version "0.500.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@holochain/hc-spin-rust-utils/-/hc-spin-rust-utils-0.500.0-rc.0.tgz#3e50e913cbb295cdd62e7cd6640c36cf63844d53"
-  integrity sha512-Es/HnEDapmQxVM6bfYnniyX24aj3KbMwJwsdLzd2CFgIG9DDAmXMYfLdzx2+8Y/kCr4AsI+avPUK9yEDwj+fXw==
+"@holochain/hc-spin-rust-utils@^0.500.0":
+  version "0.500.0"
+  resolved "https://registry.yarnpkg.com/@holochain/hc-spin-rust-utils/-/hc-spin-rust-utils-0.500.0.tgz#5366a60df289aaeb0c562690667e322fd12d710f"
+  integrity sha512-PvYxEZ69ZvT4DijJ8100FfuQy3qFMVSSaT/WXkhM4kOdk3LjNIVFx22bI3pcZWl/+z2Nz7fKMg7xFNN/RhLLWQ==
   optionalDependencies:
-    "@holochain/hc-spin-rust-utils-darwin-arm64" "0.500.0-rc.0"
-    "@holochain/hc-spin-rust-utils-darwin-x64" "0.500.0-rc.0"
-    "@holochain/hc-spin-rust-utils-linux-x64-gnu" "0.500.0-rc.0"
-    "@holochain/hc-spin-rust-utils-win32-x64-msvc" "0.500.0-rc.0"
+    "@holochain/hc-spin-rust-utils-darwin-arm64" "0.500.0"
+    "@holochain/hc-spin-rust-utils-darwin-x64" "0.500.0"
+    "@holochain/hc-spin-rust-utils-linux-x64-gnu" "0.500.0"
+    "@holochain/hc-spin-rust-utils-win32-x64-msvc" "0.500.0"
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"


### PR DESCRIPTION
### Summary

Bumps to holochain 0.5.3, including new error matching on the changed lair error in case of an incorrect password.

### TODO:
- [ ] CHANGELOG mentions all code changes.
