### PR TITLE
fix: Run postinstall script for all ubuntu releases >24

### DIFF
--- a/scripts/extend-deb-postinst.mjs
+++ b/scripts/extend-deb-postinst.mjs
@@ -45,12 +45,12 @@ if [ -e /etc/lsb-release ]; then
   done < /etc/lsb-release
 
 
-  if [ $release_version == "24.04" ]; then
+  if [ $release_version > 24* ]; then
 
-  # chown the sandbox on Ubuntu 24.04
+  # chown the sandbox on Ubuntu 24.04 or higher
   chown root '/opt/${productName}/chrome-sandbox' || true
 
-  # add AppArmor profile on Ubuntu 24.04
+  # add AppArmor profile on Ubuntu 24.04 or higher
   profile_content="# This profile allows everything and only exists to give the
 # application a name instead of having the label "unconfined"
 


### PR DESCRIPTION
### Summary

The postinstall script that runs apparmor related commands to have kangaroo apps run on Ubuntu >24 was previously constrained to only run on precisely Ubuntu 24.04. This PR changes it to run on any Ubuntu >24.

### TODO:
- [ ] CHANGELOG mentions all code changes.
