### PR TITLE
fix: bump windows runner to 2022

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-2019, macos-13, macos-latest, ubuntu-22.04]
+        platform: [windows-2022, macos-13, macos-latest, ubuntu-22.04]
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
 
@@ -128,7 +128,7 @@ jobs:
       #---------------------------------------------------------------------------------------
       - name: build, sign and upload the app (Windows)
         shell: bash
-        if: matrix.platform == 'windows-2019'
+        if: matrix.platform == 'windows-2022'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
### Summary
Bumps the Windows runner to the now oldest available Windows runner. Closes #72 

### TODO:
- [ ] CHANGELOG mentions all code changes.
