### PR TITLE
chore: bump holochain binaries to 0.5.5

### DIFF
--- a/kangaroo.config.ts
+++ b/kangaroo.config.ts
@@ -15,14 +15,14 @@ export default defineConfig({
   iceUrls: ['stun:stun.cloudflare.com:3478', 'stun:stun.l.google.com:19302'],
   bins: {
     holochain: {
-      version: '0.5.4',
+      version: '0.5.5',
       sha256: {
         'x86_64-unknown-linux-gnu':
-          '4ee7f7286b0c4a7c15ee3f46f5e6e3d78484eb61b261479bb782ec0ef82c6cc8',
+          '8c1e0c6e72fb5dde157973ee280ee494bbbad1926820829339dc67b84bc86b6e',
         'x86_64-pc-windows-msvc.exe':
-          '5f8d189b3d763ee146ac24aed01c4eb2bdec8ba80bf0fa4546a68e755b847aef',
-        'x86_64-apple-darwin': '6229a0a696da6cb3e549269009f923448890a88de69448be40e8e2dbd08062fb',
-        'aarch64-apple-darwin': 'd1fa2d979845492cad3fdb9fb6a2d950eb52ec7c4c8990dbc06d4162a595d880',
+          'cb62f336c1be9fbf8c4a823b4e6b0248903f8e07c881497c8590e923142bbdaf',
+        'x86_64-apple-darwin': '430bc76fa9561461cf038f9ce4939171712ba02ce6eefc4a0aa43ac3496e498c',
+        'aarch64-apple-darwin': 'c7535f3ce81cb6a72397d5942da6bb4a16d9eb9afc78af7ce0b861ca237d51f7',
       },
     },
     lair: {


### PR DESCRIPTION
### Summary
Bumps holochain binaries to 0.5.5

### TODO:
- [ ] CHANGELOG mentions all code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded embedded Holochain runtime to v0.5.5 across Linux, Windows, and macOS for improved stability and compatibility.
  * Refreshed platform binaries to align with the new release.
  * Incorporates upstream reliability and security fixes.
  * No user-facing changes or configuration updates required; existing workflows continue to function as before.
  * No changes to public APIs or exported configuration structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->