### PR TITLE
feat: switch to using official holochain binaries

### DIFF
--- a/kangaroo.config.ts
+++ b/kangaroo.config.ts
@@ -14,26 +14,30 @@ export default defineConfig({
   signalUrl: 'wss://dev-test-bootstrap2.holochain.org/',
   iceUrls: ['stun:stun.cloudflare.com:3478', 'stun:stun.l.google.com:19302'],
   bins: {
+    holochainVersion: '0.6.0',
+    holochainFeature: "go-pion",
     holochain: {
-      version: '0.6.0',
       sha256: {
         'x86_64-unknown-linux-gnu':
-          'ba767ac0f65ab426d01e1c4131c63c33030e41a2b8c3da7e4bdcb5d30fa2284a',
+          '8ae1282b93bcba7eaee1343831895dd3b8628d4fd8ebc5fad74def3e073e6055',
+        'aarch64-unknown-linux-gnu':
+          '9e5e8d81625201f7146d42e628b563e6db4be1b866dc06e053266cb971e4c952',
         'x86_64-pc-windows-msvc.exe':
-          '0ada079819a7ae8ea915c8319c104319a16634f0d4710a9a939d4e4109a87251',
-        'x86_64-apple-darwin': '552529ca506db2f13eb6528f628df38f1f3fac6e0e552ee75ef846a66ca16bd2',
-        'aarch64-apple-darwin': '139536e14638c7506aa6cb0816c7b5d170e71655f5590a3f458bf7bce9497515',
+          '9f838ab57b277e895b949cfec5c8a88c36d5936cce2e902706f92133d8029e77',
+        'x86_64-apple-darwin': 'd927ae095e5dbc683ae47cca336a220529f7b705d77d456cb7e4a3f2fec56adc',
+        'aarch64-apple-darwin': '0fcb1b7080496368438576b59a360a68bfa5c077ec8c83d6b5fd3d12b63b9e21',
       },
     },
     lair: {
-      version: '0.6.3',
       sha256: {
         'x86_64-unknown-linux-gnu':
-          '56beb19ca4abf39c8e2b90401a9ade10e5c395f6b95cd1853aac05643dce5a11',
+          '19bde044278161948958c8b32d9bc0744550eccd6d29260da0045fc8c0480ccd',
+        'aarch64-unknown-linux-gnu':
+          '2f4d084bb4904be8669bceb63516e5db201deee97294ba01c94ab62ba9ee8c02',
         'x86_64-pc-windows-msvc.exe':
-          '504e7e3d1afc4426990a4aee190f1137bb474ccb072f7049c23f43fc01c07009',
-        'x86_64-apple-darwin': 'd7521a0299ea425700091b78e02672b05ad4c97c2ca82643ea9ba2349b0e1e69',
-        'aarch64-apple-darwin': 'cb26b8065f52f7e3ff2d24a09100f60f61a3214e25e170ac2ef607dd040800d7',
+          'b7b29197e028f807924c1f31cd6a332af63fd3c21d8fd563ba3c0a16f7197499',
+        'x86_64-apple-darwin': '030ae46320780b53db5a8047df534da4fd1e5d8900e7864b965b1243b2dfcb40',
+        'aarch64-apple-darwin': '4ae31f48ea92c7b6f472c2f57535f5c427918bf1876ab75b89673e0b242aaa1c',
       },
     },
   },

--- a/scripts/fetch-binaries.js
+++ b/scripts/fetch-binaries.js
@@ -14,7 +14,14 @@ fs.mkdirSync(binariesDir, { recursive: true });
 let targetEnding;
 switch (process.platform) {
   case 'linux':
-    targetEnding = 'x86_64-unknown-linux-gnu';
+    switch (process.arch) {
+      case 'arm64':
+        targetEnding = 'aarch64-unknown-linux-gnu';
+        break;
+      case 'x64':
+        targetEnding = 'x86_64-unknown-linux-gnu';
+        break;
+    }
     break;
   case 'win32':
     targetEnding = 'x86_64-pc-windows-msvc.exe';
@@ -38,16 +45,17 @@ switch (process.platform) {
 const binariesAppendix = kangarooConfig.appId.slice(0, 10).replace(' ', '-');
 
 const holochainBinaryFilename = `holochain-v${
-  kangarooConfig.bins.holochain.version
+  kangarooConfig.bins.holochainVersion
 }-${binariesAppendix}${process.platform === 'win32' ? '.exe' : ''}`;
 
-const lairBinaryFilename = `lair-keystore-v${kangarooConfig.bins.lair.version}-${binariesAppendix}${
+const lairBinaryFilename = `lair-keystore-${binariesAppendix}${
   process.platform === 'win32' ? '.exe' : ''
 }`;
 
 function downloadHolochainBinary() {
-  const holochainBinaryRemoteFilename = `holochain-v${kangarooConfig.bins.holochain.version}-${targetEnding}`;
-  const holochainBinaryUrl = `https://github.com/matthme/holochain-binaries/releases/download/holochain-binaries-${kangarooConfig.bins.holochain.version}/${holochainBinaryRemoteFilename}`;
+  const holochainBinaryRemoteFilename = `holochain-${kangarooConfig.bins.holochainFeature ? `${kangarooConfig.bins.holochainFeature}-` : ''}${targetEnding}`;
+  const holochainBinaryUrl = `https://github.com/holochain/holochain/releases/download/holochain-${kangarooConfig.bins.holochainVersion}/${holochainBinaryRemoteFilename}`;
+
   const destinationPath = path.join(binariesDir, holochainBinaryFilename);
   downloadFile(
     holochainBinaryUrl,
@@ -58,8 +66,7 @@ function downloadHolochainBinary() {
 }
 
 function downloadLairBinary() {
-  const lairBinaryRemoteFilename = `lair-keystore-v${kangarooConfig.bins.lair.version}-${targetEnding}`;
-  const lairBinaryUrl = `https://github.com/matthme/holochain-binaries/releases/download/lair-binaries-${kangarooConfig.bins.lair.version}/${lairBinaryRemoteFilename}`;
+  const lairBinaryUrl = `https://github.com/holochain/holochain/releases/download/holochain-${kangarooConfig.bins.holochainVersion}/lair-keystore-${targetEnding}`;
   const destinationPath = path.join(binariesDir, lairBinaryFilename);
   downloadFile(lairBinaryUrl, destinationPath, kangarooConfig.bins.lair.sha256[targetEnding], true);
 }

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -71,15 +71,15 @@ export type KangarooConfig = {
   /**
    * URL of the bootstrap server to use.
    */
-  bootstrapUrl: string,
+  bootstrapUrl: string;
   /**
    * URL of the signaling server to use
    */
-  signalUrl: string,
+  signalUrl: string;
   /**
    * ICE Urls for the WebRTC configuration
    */
-  iceUrls: string[],
+  iceUrls: string[];
   /**
    * The network seed to use when installing the happ. If not set, the
    * network seed will automatically be generated and be based on the
@@ -118,15 +118,17 @@ export type KangarooConfig = {
     email?: string;
   };
   bins: {
-    holochain: VersionAndSha256;
-    lair: VersionAndSha256;
+    holochainVersion: string;
+    holochainFeature?: "go-pion" | "go-pion-unstable" | "iroh";
+    holochain: Sha256Hashes;
+    lair: Sha256Hashes;
   };
 };
 
-type VersionAndSha256 = {
-  version: string;
+type Sha256Hashes = {
   sha256: {
     'x86_64-unknown-linux-gnu': string;
+    'aarch64-unknown-linux-gnu': string;
     'x86_64-pc-windows-msvc.exe': string;
     'x86_64-apple-darwin': string;
     'aarch64-apple-darwin': string;


### PR DESCRIPTION
### Summary

- switches to fetching binaries from the official holochain repository
- adds support for aarch64-unknown-linux-gnu
- adds support for specifying holochain feature flag

To test locally, run `yarn fetch:binaries` in this repo and optionally change the `holochainFeature` field in `kangaroo.config.ts`. The `iroh` feature won't work yet since there is no associated release with that feature for holochain 0.6.0.

### TODO:
- [ ] CHANGELOG mentions all code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ARM64 (aarch64) systems on Linux and macOS platforms.

* **Chores**
  * Updated Holochain and Lair binary versions across all supported platforms.
  * Improved binary configuration structure for better maintainability.
  * Enhanced support for Holochain feature variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->