### PR TITLE
fix: adjust code to new kangaroo format and hc-spin-rust-utils API

### DIFF
--- a/scripts/unpack-pouch.js
+++ b/scripts/unpack-pouch.js
@@ -16,4 +16,4 @@ if (fs.existsSync(uiDir)) {
 }
 fs.mkdirSync(uiDir, { recursive: true });
 
-rustUtils.saveHappOrWebhapp(webhappPath, 'kangaroo', uiDir, resourcesDir);
+rustUtils.unpackAndSaveWebhapp(webhappPath, 'kangaroo', uiDir, resourcesDir);

--- a/src/main/const.ts
+++ b/src/main/const.ts
@@ -26,14 +26,14 @@ const BINARIES_DIRECTORY = path.join(RESOURCES_DIRECTORY, 'bins');
 
 export const HOLOCHAIN_BINARY = path.join(
   BINARIES_DIRECTORY,
-  `holochain-v${KANGAROO_CONFIG.bins.holochain.version}-${binariesAppendix}${
+  `holochain-v${KANGAROO_CONFIG.bins.holochainVersion}-${binariesAppendix}${
     process.platform === 'win32' ? '.exe' : ''
   }`
 );
 
 export const LAIR_BINARY = path.join(
   BINARIES_DIRECTORY,
-  `lair-keystore-v${KANGAROO_CONFIG.bins.lair.version}-${binariesAppendix}${
+  `lair-keystore-${binariesAppendix}${
     process.platform === 'win32' ? '.exe' : ''
   }`
 );

--- a/src/main/launch.ts
+++ b/src/main/launch.ts
@@ -76,7 +76,7 @@ export async function launch(
     kangarooFs,
     runOptions.holochainPath ? runOptions.holochainPath : HOLOCHAIN_BINARY,
     password,
-    KANGAROO_CONFIG.bins.holochain.version,
+    KANGAROO_CONFIG.bins.holochainVersion,
     kangarooFs.conductorDir,
     kangarooFs.conductorConfigPath,
     lairUrl,


### PR DESCRIPTION
### Summary

Backports some fixes that had been made as part of the [0.7.x bump PR](https://github.com/holochain/kangaroo-electron/pull/91).

(Second try, the first one accidentally got merged into main as a no-op).

### TODO:
- [ ] CHANGELOG mentions all code changes.
