### PR TITLE
fix: Ignore electron options in kangaroo's own CLI

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -45,6 +45,7 @@ kangarooCli
   .name(KANGAROO_CONFIG.productName)
   .description(`Run ${KANGAROO_CONFIG.productName} via the command line`)
   .version(KANGAROO_CONFIG.version)
+  .allowUnknownOption(true)
   .option(
     '-p, --profile <string>',
     `Runs ${KANGAROO_CONFIG.productName} with a custom profile with its own dedicated data store.`,


### PR DESCRIPTION
### Summary

This broke with the recent dependencies upgrade. The new electron-builder can inject args through the appimage depending on the launch environment. Sort of helpful, but then our CLI crashes the process because it doesn't recognize the arguments intended for electron.

### TODO:
- [ ] CHANGELOG mentions all code changes.
